### PR TITLE
Shorten hamburger dropdown Length Rem 

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,10 +49,6 @@
             document.head.append(style);
         }
         if (!document.cookie.split('; ').find((row) => row.startsWith('doSomethingOnlyOnce'))) {
-            // Note that we are setting `SameSite=None;` in this example because the example
-            // needs to work cross-origin.
-            // It is more common not to set the `SameSite` attribute, which results in the default,
-            // and more secure, value of `SameSite=Lax;`
             document.cookie = "doSomethingOnlyOnce=true; expires=Fri, 31 Dec 9999 23:59:59 GMT; SameSite=None; Secure";
 
             const output = document.getElementById('do-once')
@@ -62,7 +58,6 @@
             console.log("in Null so it should be animation");
         }
         else{
-            // do cookie exists stuff
             logo = document.getElementById("logo")
             logo.src = "./images/brawlback_finalFrame.png"
             console.log("In Not Null so it should be still")
@@ -72,7 +67,6 @@
             });
         }
         
-
         hamburger = document.querySelector(".hamburger")
         hamburger.onclick = function() {
             navBar = document.querySelector(".nav-bar")

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <title>BrawlBack</title>
 </head>
 <body>
+    <!-- NavBar -->
     <header>
         <img src="/images/brawlback_textraw.png" alt="BrawlBack Logo" width="20%">
         <div class="hamburger">
@@ -31,6 +32,7 @@
         </nav>
     </header>
 
+    <!-- Animation, Description, Download Button -->
     <section>
         <div class="whatWeAre__image">
             <img id="logo" src="./images/brawlback_animation.gif" >
@@ -42,6 +44,8 @@
             <a href="#" class="myButton">Download</a>
         </div>
     </section>
+
+    <!-- Javascript -->
     <script>
         function addStyle(styleString) {
             const style = document.createElement('style');
@@ -52,7 +56,6 @@
             document.cookie = "doSomethingOnlyOnce=true; expires=Fri, 31 Dec 9999 23:59:59 GMT; SameSite=None; Secure";
 
             const output = document.getElementById('do-once')
-            output.textContent = '> Do something here!'
             logo = document.getElementById("logo")
             logo.src = "./images/brawlback_animation.gif"
             console.log("in Null so it should be animation");

--- a/styles.css
+++ b/styles.css
@@ -43,7 +43,6 @@ header {
 
 .nav-bar ul li a:hover{
     color: #424343;
-
     background: #44cea4;
 }
 
@@ -90,13 +89,13 @@ header {
     }
 
     .nav-bar.active {
-        height: 450px;
+        height: 12rem;
     }
 
     .nav-bar ul {
         display: block;
         width: fit-content;
-        margin: 80px auto 0 auto;
+        margin: 1rem auto 0 auto;
         text-align: center;
         transition: 0.5s;
         opacity: 0;


### PR DESCRIPTION
Just shortened the Hamburger drop down no need for it to be 450px, also added comments showing what section is what, changed length of drop down from px to rem to be adaptable.

<img width="891" alt="image" src="https://user-images.githubusercontent.com/63530023/208743488-c63c9f3f-c391-4930-a9d8-fa735c2b9a3e.png">
