### PR TITLE
Navbar Logo larger for smaller devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <script src="navbar.js"></script>
     <!-- NavBar -->
     <header>
-        <img src="/images/brawlback_textraw.png" alt="BrawlBack Logo" width="20%">
+        <img class="brawlBackLogo" src="/images/brawlback_textraw.png" alt="BrawlBack Logo">
         <div class="hamburger">
             <div class="line"></div>
             <div class="line"></div>

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,10 @@ header {
     padding: 0 100px;
 }
 
+.brawlBackLogo {
+    width: 20%;
+}
+
 .hamburger {
     display: none;
 }
@@ -70,6 +74,10 @@ header {
     .hamburger {
         display: block;
         cursor: pointer;
+    }
+
+    .brawlBackLogo{
+        width: 50%;
     }
 
     .hamburger .line {


### PR DESCRIPTION
Heres how it looks on the iphone 12 Pro
<img width="332" alt="image" src="https://user-images.githubusercontent.com/63530023/209459540-2ef7efbe-cf8c-49ec-af92-35f0e8c87178.png">

before it was too small 