### PR TITLE
Center Download Page and Make Navbar logo smaller for large devices

### DIFF
--- a/css/download.css
+++ b/css/download.css
@@ -1,10 +1,10 @@
 .downloadParent {
-    display: inline-flex;
-    width: 100%;
+    display: flex;
+    justify-content: center;
+    margin-top: 2rem;
 }
 .downloadDiv {
     margin-top: 2.2%;
-    margin-left: 10%;
 }
 
 .downloadTitle {
@@ -39,15 +39,6 @@
     list-style: circle;
 }
 
-@media only screen and (max-width: 900px) {
-    .downloadParent{
-        display:contents
-    }
-    .ifMobile {
-        margin-bottom: 7rem;
-    }
-}
-
 .instructionDiv {
     margin-top: 2.2%;
     margin-left: 10%;
@@ -74,4 +65,25 @@
     color: #becdc7;
     margin-bottom: 2%;
     max-width: 30rem;   
+}
+
+@media only screen and (max-width: 900px) {
+    .downloadParent{
+        display:contents
+    }
+
+    .downloadDiv {
+        margin-top: 2.2%;
+        margin-left: 5%;
+    }
+
+    .instructionDiv {
+        margin-top: 2.2%;
+        margin-left: 5%;
+    }
+    
+
+    .ifMobile {
+        margin-bottom: 7rem;
+    }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -58,6 +58,12 @@ header {
     background: #44cea4;
 }
 
+@media only screen and (min-width: 1500px) {
+    .brawlBackLogo {
+        width: 70%;
+    }
+}
+
 @media only screen and (max-width: 1320px) {
     header {
         padding: 0 50px;


### PR DESCRIPTION
It is centered now
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/63530023/209461110-b20d7ee2-ef0a-4b53-a7e9-3965eae20548.png">

