### PR TITLE
Download page for smaller devices

### DIFF
--- a/css/download.css
+++ b/css/download.css
@@ -88,7 +88,7 @@
     }
 }
 
-@media screen and (max-height: 700px) {
+@media screen and (max-height: 725px) {
     
     .downloadParent {
         margin-top: 0;

--- a/css/download.css
+++ b/css/download.css
@@ -87,3 +87,18 @@
         margin-bottom: 7rem;
     }
 }
+
+@media screen and (max-height: 700px) {
+    
+    .downloadParent {
+        margin-top: 0;
+    }
+    
+    .instructionDiv {
+        margin-top: 1%;
+        margin-left: 10%;
+    }
+    .downloadDiv {
+        margin-top: 1%;
+    }
+}

--- a/js/os.js
+++ b/js/os.js
@@ -30,6 +30,8 @@ function changeDownloadButton(){
   else if(os == "Linux") {
       buttonDownload.setAttribute("href", "#")
       buttonDownload.setAttribute("download", "BrawlBackLinux.png")
+  }else{
+      buttonDownload.textContent="Not Available On Device";
   }
 }
 


### PR DESCRIPTION
If screen is less than 725px then it will decrease the margin-top to only 1% this is so that the space between footer and the bottom of the div is not too cramped.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/63530023/209485462-fd9fa697-51ce-49db-8a63-81ecba35ed90.png">
